### PR TITLE
InpPerImage modification in convlayer.h

### DIFF
--- a/bnn/src/library/hls/convlayer.h
+++ b/bnn/src/library/hls/convlayer.h
@@ -80,7 +80,7 @@ void ConvLayer_Batch(hls::stream<ap_uint<InStreamW>>  &in,
 #pragma HLS INLINE
   unsigned const MatrixW = ConvKernelDim * ConvKernelDim * IFMChannels;
   unsigned const MatrixH = OFMChannels;
-  unsigned const InpPerImage = IFMDim*IFMDim*IFMChannels/InStreamW * TSrcI::width;
+  unsigned const InpPerImage = (float)(IFMDim*IFMDim*IFMChannels)/InStreamW * TSrcI::width;
   WidthAdjustedInputStream <InStreamW, SIMD*TSrcI::width, InpPerImage>  wa_in (in,  reps);
   WidthAdjustedOutputStream <PE*TDstI::width, OutStreamW, OFMDim * OFMDim * (OFMChannels / PE)>  mvOut (out,  reps);
   hls::stream<ap_uint<SIMD*TSrcI::width> > convInp("StreamingConvLayer_Batch.convInp");

--- a/bnn/src/library/hls/dma.h
+++ b/bnn/src/library/hls/dma.h
@@ -48,11 +48,13 @@
 #include <ap_int.h>
 #include <hls_stream.h>
 
+unsigned int paddedSizeHW(unsigned int in, unsigned int padTo);
+
 // essentially small DMA generators, moving data between mem-mapped arrays and streams
 template<unsigned int DataWidth, unsigned int numBytes>
 void Mem2Stream(ap_uint<DataWidth> * in, hls::stream<ap_uint<DataWidth> > & out) {
   CASSERT_DATAFLOW(DataWidth % 8 == 0);
-  const unsigned int numWords = numBytes / (DataWidth / 8);
+  const unsigned int numWords = paddedSizeHW(numBytes, (DataWidth / 8)) / (DataWidth / 8);
   CASSERT_DATAFLOW(numWords != 0);
   for (unsigned int i = 0; i < numWords; i++) {
 #pragma HLS PIPELINE II=1
@@ -80,7 +82,7 @@ void Stream2Mem(hls::stream<ap_uint<DataWidth> > & in, ap_uint<DataWidth> * out)
 // checking the modulo takes a lot more resources)
 template<unsigned int DataWidth, unsigned int numBytes>
 void Mem2Stream_Batch(ap_uint<DataWidth> * in, hls::stream<ap_uint<DataWidth> > & out, const unsigned int numReps) {
-  const unsigned int indsPerRep = numBytes / (DataWidth / 8);
+  const unsigned int indsPerRep = paddedSizeHW(numBytes, (DataWidth / 8)) / (DataWidth / 8);
   unsigned int rep = 0;
   // make sure Mem2Stream does not get inlined here
   // we lose burst inference otherwise

--- a/bnn/src/library/hls/streamtools.h
+++ b/bnn/src/library/hls/streamtools.h
@@ -142,9 +142,10 @@ void StreamingDataWidthConverter_Batch(hls::stream<ap_uint<InWidth> > & in,
       // increment read input count
       i++;
       // wraparound logic to recreate nested loop functionality
-      if (i == inPerOut) {
+      if (i == inPerOut || t == (totalIters-1)) {
         i = 0;
         out.write(eo);
+	eo = 0;
       }
     }
   }


### PR DESCRIPTION
Hello,
I send a pull request.
In the modified part below, the fractional part may be generated by division.

.-  unsigned const InpPerImage = IFMDim*IFMDim*IFMChannels/InStreamW * TSrcI::width;
.+  unsigned const InpPerImage = (float)(IFMDim*IFMDim*IFMChannels)/InStreamW * TSrcI::width;


I changed IFMDim and realized that the decimal part occurred while I was executing it.
Please check.